### PR TITLE
Add unsaved changes tracking and closing prompt

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -25,7 +25,33 @@ namespace Osadka
         }
         private void MainWindow_Closing(object? sender, CancelEventArgs e)
         {
+            if (!_vm.IsDirty)
+                return;
 
+            var result = MessageBox.Show(
+                "Сохранить изменения перед выходом?",
+                "Osadka",
+                MessageBoxButton.YesNoCancel,
+                MessageBoxImage.Question);
+
+            if (result == MessageBoxResult.Cancel)
+            {
+                e.Cancel = true;
+                return;
+            }
+
+            if (result == MessageBoxResult.Yes)
+            {
+                if (_vm.SaveProjectCommand.CanExecute(null))
+                {
+                    _vm.SaveProjectCommand.Execute(null);
+                }
+
+                if (_vm.IsDirty)
+                {
+                    e.Cancel = true;
+                }
+            }
         }
         private async void OnCheckUpdateClick(object sender, RoutedEventArgs e)
         {


### PR DESCRIPTION
## Summary
- add IsDirty tracking to MainViewModel with subscriptions to data collections and rows
- reset the dirty flag when projects are loaded, created, or saved
- prompt the user to save when closing the main window if there are unsaved changes

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d02c7d356c83209363f828753b3b3b