### PR TITLE
Stop rescaling coordinates on unit change

### DIFF
--- a/ViewModels/RawDataViewModel.cs
+++ b/ViewModels/RawDataViewModel.cs
@@ -68,26 +68,18 @@ namespace Osadka.ViewModels
         [ObservableProperty]
         private CoordUnits coordUnit = CoordUnits.Millimeters;
 
-        // Преобразование старых значений в новые через отношение масштабов
         partial void OnCoordUnitChanged(CoordUnits oldVal, CoordUnits newVal)
         {
-            var oldU = Map(oldVal);
-            var newU = Map(newVal);
-            double k = UnitConverter.ToMm(1.0, newU) / UnitConverter.ToMm(1.0, oldU);
+            _ = oldVal; // старое значение не требуется, данные остаются в мм
+            // Храним данные в миллиметрах, поэтому при смене отображаемой единицы
+            // ничего не пересчитываем, а просто обновляем SourceUnit, чтобы новые
+            // входящие значения корректно приводились к мм.
+            SourceUnit = Map(newVal);
 
-            foreach (var p in CoordRows)
-            {
-                p.X *= k;
-                p.Y *= k;
-            }
-               foreach (var r in DataRows)
-                   {
-                       if (r.Mark is double m) r.Mark = m * k;
-                       if (r.Settl is double s) r.Settl = s * k;
-                       if (r.Total is double t) r.Total = t * k;
-                   }
-            // Держим SourceUnit согласованным с CoordUnit
-            SourceUnit = newU;
+            // Сообщаем представлению о смене масштаба.
+            OnPropertyChanged(nameof(CoordScale));
+            OnPropertyChanged(nameof(CoordRows));
+            OnPropertyChanged(nameof(DataRows));
         }
 
         // Удобные аксессоры


### PR DESCRIPTION
## Summary
- keep coordinate and settlement data stored in millimetres when the displayed unit changes
- ensure the source unit is updated without re-scaling existing values and notify bindings of the scale change

## Testing
- `dotnet build` *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68f3a3f3d1b48321a1110f835a6d8a15