### PR TITLE
Prompt to save unsaved data on close

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -25,7 +25,11 @@ namespace Osadka
         }
         private void MainWindow_Closing(object? sender, CancelEventArgs e)
         {
+            if (_vm is null)
+                return;
 
+            if (!_vm.ConfirmClose())
+                e.Cancel = true;
         }
         private async void OnCheckUpdateClick(object sender, RoutedEventArgs e)
         {

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -240,23 +240,38 @@ namespace Osadka.ViewModels
 
         private void SaveProject()
         {
-            if (_currentPath == null)
-            {
-                SaveAsProject();
-                return;
-            }
-            SaveTo(_currentPath);
+            TrySaveProject();
         }
 
         private void SaveAsProject()
+        {
+            TrySaveProjectAs();
+        }
+
+        private bool TrySaveProject()
+        {
+            if (_currentPath == null)
+            {
+                return TrySaveProjectAs();
+            }
+
+            SaveTo(_currentPath);
+            return true;
+        }
+
+        private bool TrySaveProjectAs()
         {
             var dlg = new SaveFileDialog
             {
                 Filter = "Osadka Project (*.osd)|*.osd"
             };
-            if (dlg.ShowDialog() != true) return;
-            SaveTo(dlg.FileName);
+
+            if (dlg.ShowDialog() != true)
+                return false;
+
             _currentPath = dlg.FileName;
+            SaveTo(_currentPath);
+            return true;
         }
 
         void SaveTo(string path)
@@ -418,6 +433,26 @@ namespace Osadka.ViewModels
             _isDirty = false;
             if (SaveProjectCommand is RelayCommand relay)
                 relay.NotifyCanExecuteChanged();
+        }
+
+        public bool ConfirmClose()
+        {
+            if (!_isDirty)
+                return true;
+
+            var result = MessageBox.Show(
+                "Есть несохранённые изменения. Сохранить проект перед выходом?",
+                "Osadka",
+                MessageBoxButton.YesNoCancel,
+                MessageBoxImage.Warning);
+
+            if (result == MessageBoxResult.Cancel)
+                return false;
+
+            if (result == MessageBoxResult.Yes)
+                return TrySaveProject();
+
+            return true;
         }
 
         private void DoQuickExport()


### PR DESCRIPTION
## Summary
- warn about unsaved project changes when the main window is closed
- reuse the save helpers so the prompt can save or cancel depending on the user choice

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_6907907daadc832e883ecf47d237236b