### PR TITLE
Исправить ложные предупреждения о несохранённых данных

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -25,7 +25,30 @@ namespace Osadka
         }
         private void MainWindow_Closing(object? sender, CancelEventArgs e)
         {
+            if (_vm is null)
+                return;
 
+            if (!_vm.HasUnsavedChanges)
+                return;
+
+            var result = MessageBox.Show(
+                "Есть несохранённые изменения. Сохранить проект перед выходом?",
+                "Несохранённые данные",
+                MessageBoxButton.YesNoCancel,
+                MessageBoxImage.Warning);
+
+            switch (result)
+            {
+                case MessageBoxResult.Cancel:
+                    e.Cancel = true;
+                    break;
+
+                case MessageBoxResult.Yes:
+                    _vm.SaveProjectCommand.Execute(null);
+                    if (_vm.HasUnsavedChanges)
+                        e.Cancel = true;
+                    break;
+            }
         }
         private async void OnCheckUpdateClick(object sender, RoutedEventArgs e)
         {


### PR DESCRIPTION
## Summary
- отключено отслеживание изменений при создании/загрузке проекта, чтобы не помечать состояние как изменённое
- упрощён расчёт признака несохранённых данных до фактического dirty-флага
- обновлено сохранение проекта, чтобы путь устанавливался до сериализации и восстанавливался при ошибке

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6907907daadc832e883ecf47d237236b