### PR TITLE
Refine cycle state gantt grouping

### DIFF
--- a/ViewModels/CycleScaleViewModel.cs
+++ b/ViewModels/CycleScaleViewModel.cs
@@ -10,8 +10,6 @@ using System.Windows.Media;
 
 namespace Osadka.ViewModels
 {
-    public record LegendItem(string Label, Brush Brush);
-
     public partial class CycleScaleViewModel : ObservableObject
     {
         private readonly RawDataViewModel _raw;
@@ -19,9 +17,9 @@ namespace Osadka.ViewModels
 
         public ReadOnlyObservableCollection<CycleStateGroup> Groups => _groups;
 
-        public ObservableCollection<int> CycleAxis { get; } = new();
+        public ObservableCollection<CycleMeaningGroup> DisplayGroups { get; } = new();
 
-        public ObservableCollection<LegendItem> LegendItems { get; }
+        public ObservableCollection<int> CycleAxis { get; } = new();
 
         public IRelayCommand<CycleStateGroup> ToggleGroupCommand { get; }
 
@@ -41,10 +39,6 @@ namespace Osadka.ViewModels
             _groups = new ReadOnlyObservableCollection<CycleStateGroup>(_raw.CycleGroups);
             ToggleGroupCommand = new RelayCommand<CycleStateGroup>(g => _raw.ToggleGroup(g), g => g is not null);
 
-            LegendItems = new ObservableCollection<LegendItem>(
-                _brushes.OrderBy(kv => kv.Key)
-                        .Select(kv => new LegendItem(GetLegendLabel(kv.Key), kv.Value)));
-
             _raw.CycleGroups.CollectionChanged += OnGroupsChanged;
             _raw.CycleGroupsChanged += (_, __) => OnCycleGroupsChanged();
             _raw.PropertyChanged += RawOnPropertyChanged;
@@ -54,6 +48,7 @@ namespace Osadka.ViewModels
             // Построить отрезки для уже имеющихся групп и окрасить
             foreach (var g in _raw.CycleGroups) g.RebuildSegments();
             ApplyColors();
+            RefreshDisplayGroups();
         }
 
 
@@ -70,6 +65,7 @@ namespace Osadka.ViewModels
         private void OnGroupsChanged(object? sender, NotifyCollectionChangedEventArgs e)
         {
             ApplyColors();
+            RefreshDisplayGroups();
         }
 
         private void OnCycleGroupsChanged()
@@ -77,6 +73,7 @@ namespace Osadka.ViewModels
             UpdateAxis();
             foreach (var g in _raw.CycleGroups) g.RebuildSegments();
             ApplyColors();
+            RefreshDisplayGroups();
             OnPropertyChanged(nameof(Groups));
         }
 
@@ -119,6 +116,22 @@ namespace Osadka.ViewModels
 
                 foreach (var seg in group.Segments)
                     seg.Brush = GetBrushForKind(seg.Kind);
+                foreach (var meaning in group.MeaningGroups)
+                {
+                    foreach (var seg in meaning.Segments)
+                        seg.Brush = GetBrushForKind(seg.Kind);
+                }
+            }
+        }
+
+        private void RefreshDisplayGroups()
+        {
+            DisplayGroups.Clear();
+
+            foreach (var group in _raw.CycleGroups)
+            {
+                foreach (var meaning in group.MeaningGroups)
+                    DisplayGroups.Add(meaning);
             }
         }
 
@@ -127,16 +140,5 @@ namespace Osadka.ViewModels
             => _brushes.TryGetValue(kind, out var brush)
                 ? brush
                 : Brushes.LightGray;
-
-        private static string GetLegendLabel(CycleStateKind kind) => kind switch
-        {
-            CycleStateKind.Measured => "Измерено",
-            CycleStateKind.New => "Новая точка",
-            CycleStateKind.NoAccess => "Нет доступа",
-            CycleStateKind.Destroyed => "Уничтожена",
-            CycleStateKind.Text => "Особая отметка",
-            CycleStateKind.Missing => "Нет данных",
-            _ => kind.ToString()
-        };
     }
 }

--- a/Views/CycleScalePage.xaml
+++ b/Views/CycleScalePage.xaml
@@ -22,31 +22,72 @@
         <TextBlock Grid.Row="0" Text="Шкала циклов" FontSize="20" FontWeight="SemiBold" Margin="0,0,0,12"/>
 
         <!-- Ось циклов (над левым Гантом) -->
-        <Border Grid.Row="1" Padding="8" Background="#F5F7FB" CornerRadius="6">
-            <ItemsControl ItemsSource="{Binding CycleAxis}"
-                          AlternationCount="{Binding CycleAxis.Count}">
-                <ItemsControl.ItemsPanel>
-                    <ItemsPanelTemplate>
-                        <Grid ui:GridHelpers.ColumnsCount="{Binding CycleAxis.Count}"
-                              ui:GridHelpers.SharedGroupPrefix="GanttCycle"/>
-                    </ItemsPanelTemplate>
-                </ItemsControl.ItemsPanel>
+        <Border Grid.Row="1" Padding="12,8" Background="#F5F7FB" CornerRadius="6">
+            <Grid SnapsToDevicePixels="True">
+                <Grid ui:GridHelpers.ColumnsCount="{Binding CycleAxis.Count}"
+                      ui:GridHelpers.SharedGroupPrefix="GanttCycle">
+                    <ItemsControl ItemsSource="{Binding CycleAxis}"
+                                  AlternationCount="{Binding CycleAxis.Count}"
+                                  IsHitTestVisible="False">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <Grid ui:GridHelpers.ColumnsCount="{Binding CycleAxis.Count}"
+                                      ui:GridHelpers.SharedGroupPrefix="GanttCycle"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
 
-                <ItemsControl.ItemContainerStyle>
-                    <Style TargetType="ContentPresenter">
-                        <Setter Property="Grid.Column"
-                                Value="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=AlternationIndex}"/>
-                    </Style>
-                </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Grid.Column"
+                                        Value="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=AlternationIndex}"/>
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
 
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <Border Margin="4" Padding="6" Background="#DEE7FF" CornerRadius="4" MinWidth="60">
-                            <TextBlock Text="{Binding}" HorizontalAlignment="Center" FontWeight="SemiBold"/>
-                        </Border>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border BorderBrush="#D5D9E3"
+                                        BorderThickness="0,0,1,0"
+                                        Margin="0"
+                                        SnapsToDevicePixels="True"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+
+                    <ItemsControl ItemsSource="{Binding CycleAxis}"
+                                  AlternationCount="{Binding CycleAxis.Count}"
+                                  Margin="0"
+                                  IsHitTestVisible="False">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <Grid ui:GridHelpers.ColumnsCount="{Binding CycleAxis.Count}"
+                                      ui:GridHelpers.SharedGroupPrefix="GanttCycle"/>
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Grid.Column"
+                                        Value="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=AlternationIndex}"/>
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border Padding="4,0,4,6"
+                                        BorderBrush="#D5D9E3"
+                                        BorderThickness="0,0,0,1"
+                                        MinWidth="60"
+                                        HorizontalAlignment="Stretch"
+                                        SnapsToDevicePixels="True">
+                                    <TextBlock Text="{Binding}"
+                                               HorizontalAlignment="Center"
+                                               FontWeight="SemiBold"/>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </Grid>
+            </Grid>
         </Border>
 
         <!-- Контент: 2 колонки -->
@@ -59,10 +100,10 @@
             </Grid.ColumnDefinitions>
 
             <!-- ЛЕВО: Гант -->
-            <Border Grid.Column="0" BorderBrush="#E1E4EB" BorderThickness="1" CornerRadius="6">
+            <Border Grid.Column="0" BorderBrush="#E1E4EB" BorderThickness="1" CornerRadius="6" SnapsToDevicePixels="True">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <!-- Один ряд на группу: слева её имя, справа полосы -->
-                    <ItemsControl ItemsSource="{Binding DisplayGroups}">
+                    <ItemsControl ItemsSource="{Binding DisplayGroups}" AlternationCount="1000">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <VirtualizingStackPanel/>
@@ -71,64 +112,102 @@
 
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Grid Margin="8,6">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="140"/>
+                                <Border BorderBrush="#E1E4EB" BorderThickness="0,1,0,0" Padding="8,6" SnapsToDevicePixels="True">
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="160"/>
+                                            <!-- подпись группы -->
+                                            <ColumnDefinition Width="*"/>
+                                            <!-- полосы -->
+                                        </Grid.ColumnDefinitions>
+
                                         <!-- подпись группы -->
-                                        <ColumnDefinition Width="*"/>
-                                        <!-- полосы -->
-                                    </Grid.ColumnDefinitions>
+                                        <Border Grid.Column="0"
+                                                BorderBrush="#E1E4EB"
+                                                BorderThickness="0,0,1,0"
+                                                Padding="0,0,10,0"
+                                                SnapsToDevicePixels="True">
+                                            <TextBlock VerticalAlignment="Center"
+                                                       FontWeight="SemiBold"
+                                                       TextWrapping="Wrap"
+                                                       Text="{Binding Title}"/>
+                                        </Border>
 
-                                    <!-- подпись группы -->
-                                    <TextBlock Grid.Column="0"
-                                               VerticalAlignment="Center"
-                                               Margin="0,0,10,0"
-                                               FontWeight="SemiBold"
-                                               TextWrapping="Wrap"
-                                               Text="{Binding Title}"/>
+                                        <!-- Полосы Ганта (склеенные сегменты) -->
+                                        <Grid Grid.Column="1"
+                                              ui:GridHelpers.ColumnsCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                              ui:GridHelpers.SharedGroupPrefix="GanttCycle"
+                                              SnapsToDevicePixels="True">
+                                            <!-- Вертикальные линии -->
+                                            <ItemsControl ItemsSource="{Binding DataContext.CycleAxis, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                          AlternationCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                          IsHitTestVisible="False">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <Grid ui:GridHelpers.ColumnsCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                              ui:GridHelpers.SharedGroupPrefix="GanttCycle"/>
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
 
+                                                <ItemsControl.ItemContainerStyle>
+                                                    <Style TargetType="ContentPresenter">
+                                                        <Setter Property="Grid.Column"
+                                                                Value="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=AlternationIndex}"/>
+                                                    </Style>
+                                                </ItemsControl.ItemContainerStyle>
 
-                                    <!-- Полосы Ганта (склеенные сегменты) -->
-                                    <Grid Grid.Column="1"
-                                          ui:GridHelpers.ColumnsCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                          ui:GridHelpers.SharedGroupPrefix="GanttCycle">
-                                        <!-- Сегменты -->
-                                        <ItemsControl ItemsSource="{Binding Segments}"
-                                                      AlternationCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}">
-                                            <ItemsControl.ItemsPanel>
-                                                <ItemsPanelTemplate>
-                                                    <Grid ui:GridHelpers.ColumnsCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                          ui:GridHelpers.SharedGroupPrefix="GanttCycle"/>
-                                                </ItemsPanelTemplate>
-                                            </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Border BorderBrush="#E1E4EB"
+                                                                BorderThickness="0,0,1,0"
+                                                                Margin="0"
+                                                                SnapsToDevicePixels="True"/>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
 
-                                            <ItemsControl.ItemContainerStyle>
-                                                <Style TargetType="ContentPresenter">
-                                                    <Setter Property="Grid.Column" Value="{Binding StartIndex}"/>
-                                                    <Setter Property="Grid.ColumnSpan" Value="{Binding Span}"/>
-                                                </Style>
-                                            </ItemsControl.ItemContainerStyle>
+                                            <!-- Сегменты -->
+                                            <ItemsControl ItemsSource="{Binding Segments}"
+                                                          AlternationCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <Grid ui:GridHelpers.ColumnsCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                              ui:GridHelpers.SharedGroupPrefix="GanttCycle"/>
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
 
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate>
-                                                    <Border Height="28" Margin="2" CornerRadius="4" Background="{Binding Brush}">
-                                                        <Border.ToolTip>
-                                                            <StackPanel>
-                                                                <TextBlock>
-                                                                    <Run Text="Циклы: "/>
-                                                                    <Run Text="{Binding CycleFrom}"/>
-                                                                    <Run Text="–"/>
-                                                                    <Run Text="{Binding CycleTo}"/>
-                                                                </TextBlock>
-                                                                <TextBlock Text="{Binding Annotation}" TextWrapping="Wrap"/>
-                                                            </StackPanel>
-                                                        </Border.ToolTip>
-                                                    </Border>
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
+                                                <ItemsControl.ItemContainerStyle>
+                                                    <Style TargetType="ContentPresenter">
+                                                        <Setter Property="Grid.Column" Value="{Binding StartIndex}"/>
+                                                        <Setter Property="Grid.ColumnSpan" Value="{Binding Span}"/>
+                                                    </Style>
+                                                </ItemsControl.ItemContainerStyle>
+
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Border Height="28"
+                                                                Margin="2"
+                                                                CornerRadius="4"
+                                                                Background="{Binding Brush}"
+                                                                SnapsToDevicePixels="True">
+                                                            <Border.ToolTip>
+                                                                <StackPanel>
+                                                                    <TextBlock>
+                                                                        <Run Text="Циклы: "/>
+                                                                        <Run Text="{Binding CycleFrom}"/>
+                                                                        <Run Text="–"/>
+                                                                        <Run Text="{Binding CycleTo}"/>
+                                                                    </TextBlock>
+                                                                    <TextBlock Text="{Binding Annotation}" TextWrapping="Wrap"/>
+                                                                </StackPanel>
+                                                            </Border.ToolTip>
+                                                        </Border>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </Grid>
                                     </Grid>
-                                </Grid>
+                                </Border>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>

--- a/Views/CycleScalePage.xaml
+++ b/Views/CycleScalePage.xaml
@@ -62,7 +62,7 @@
             <Border Grid.Column="0" BorderBrush="#E1E4EB" BorderThickness="1" CornerRadius="6">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
                     <!-- Один ряд на группу: слева её имя, справа полосы -->
-                    <ItemsControl ItemsSource="{Binding Groups}">
+                    <ItemsControl ItemsSource="{Binding DisplayGroups}">
                         <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
                                 <VirtualizingStackPanel/>
@@ -80,14 +80,12 @@
                                     </Grid.ColumnDefinitions>
 
                                     <!-- подпись группы -->
-                                    <TextBlock Grid.Column="0" VerticalAlignment="Center" Margin="0,0,10,0" FontWeight="SemiBold">
-                                        <TextBlock.Text>
-                                            <PriorityBinding>
-                                                <Binding Path="DisplayName"/>
-                                                <Binding Source="Группа"/>
-                                            </PriorityBinding>
-                                        </TextBlock.Text>
-                                    </TextBlock>
+                                    <TextBlock Grid.Column="0"
+                                               VerticalAlignment="Center"
+                                               Margin="0,0,10,0"
+                                               FontWeight="SemiBold"
+                                               TextWrapping="Wrap"
+                                               Text="{Binding Title}"/>
 
 
                                     <!-- Полосы Ганта (склеенные сегменты) -->
@@ -137,7 +135,7 @@
                 </ScrollViewer>
             </Border>
 
-            <!-- ПРАВО: список групп + легенда -->
+            <!-- ПРАВО: список групп -->
             <ScrollViewer Grid.Column="1" Margin="16,0,0,0" VerticalScrollBarVisibility="Auto">
                 <StackPanel>
 
@@ -175,23 +173,6 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-
-                    <Border Padding="10" Background="#F7F9FC" CornerRadius="6" BorderBrush="#D5D9E3" BorderThickness="1">
-                        <StackPanel>
-                            <TextBlock Text="Легенда" FontWeight="SemiBold" Margin="0,0,0,8"/>
-                            <ItemsControl ItemsSource="{Binding LegendItems}">
-                                <ItemsControl.ItemTemplate>
-                                    <DataTemplate>
-                                        <StackPanel Orientation="Horizontal" Margin="8,4">
-                                            <Rectangle Width="18" Height="18" Fill="{Binding Brush}" Stroke="#33000000" StrokeThickness="1" Margin="0,0,6,0"/>
-                                            <TextBlock Text="{Binding Label}" VerticalAlignment="Center"/>
-                                        </StackPanel>
-                                    </DataTemplate>
-                                </ItemsControl.ItemTemplate>
-                            </ItemsControl>
-                        </StackPanel>
-                    </Border>
-
                 </StackPanel>
             </ScrollViewer>
         </Grid>

--- a/Views/CycleScalePage.xaml
+++ b/Views/CycleScalePage.xaml
@@ -124,7 +124,7 @@
                                         <!-- подпись группы -->
                                         <Border Grid.Column="0"
                                                 BorderBrush="#E1E4EB"
-                                                BorderThickness="0,0,1,0"
+                                                BorderThickness="0,0,1,1"
                                                 Padding="0,0,10,0"
                                                 SnapsToDevicePixels="True">
                                             <TextBlock VerticalAlignment="Center"
@@ -134,78 +134,83 @@
                                         </Border>
 
                                         <!-- Полосы Ганта (склеенные сегменты) -->
-                                        <Grid Grid.Column="1"
-                                              ui:GridHelpers.ColumnsCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                              ui:GridHelpers.SharedGroupPrefix="GanttCycle"
-                                              SnapsToDevicePixels="True">
-                                            <!-- Вертикальные линии -->
-                                            <ItemsControl ItemsSource="{Binding DataContext.CycleAxis, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                          AlternationCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                          IsHitTestVisible="False">
-                                                <ItemsControl.ItemsPanel>
-                                                    <ItemsPanelTemplate>
-                                                        <Grid ui:GridHelpers.ColumnsCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                              ui:GridHelpers.SharedGroupPrefix="GanttCycle"/>
-                                                    </ItemsPanelTemplate>
-                                                </ItemsControl.ItemsPanel>
+                                        <Border Grid.Column="1"
+                                                BorderBrush="#E1E4EB"
+                                                BorderThickness="0,0,1,1"
+                                                SnapsToDevicePixels="True">
+                                            <Grid ui:GridHelpers.ColumnsCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                  ui:GridHelpers.SharedGroupPrefix="GanttCycle"
+                                                  SnapsToDevicePixels="True">
+                                                <!-- Ячейки сетки -->
+                                                <ItemsControl ItemsSource="{Binding DataContext.CycleAxis, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                              AlternationCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                              IsHitTestVisible="False">
+                                                    <ItemsControl.ItemsPanel>
+                                                        <ItemsPanelTemplate>
+                                                            <Grid ui:GridHelpers.ColumnsCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                                  ui:GridHelpers.SharedGroupPrefix="GanttCycle"/>
+                                                        </ItemsPanelTemplate>
+                                                    </ItemsControl.ItemsPanel>
 
-                                                <ItemsControl.ItemContainerStyle>
-                                                    <Style TargetType="ContentPresenter">
-                                                        <Setter Property="Grid.Column"
-                                                                Value="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=AlternationIndex}"/>
-                                                    </Style>
-                                                </ItemsControl.ItemContainerStyle>
+                                                    <ItemsControl.ItemContainerStyle>
+                                                        <Style TargetType="ContentPresenter">
+                                                            <Setter Property="Grid.Column"
+                                                                    Value="{Binding RelativeSource={RelativeSource AncestorType=ItemsControl}, Path=AlternationIndex}"/>
+                                                        </Style>
+                                                    </ItemsControl.ItemContainerStyle>
 
-                                                <ItemsControl.ItemTemplate>
-                                                    <DataTemplate>
-                                                        <Border BorderBrush="#E1E4EB"
-                                                                BorderThickness="0,0,1,0"
-                                                                Margin="0"
-                                                                SnapsToDevicePixels="True"/>
-                                                    </DataTemplate>
-                                                </ItemsControl.ItemTemplate>
-                                            </ItemsControl>
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <Border BorderBrush="#E1E4EB"
+                                                                    BorderThickness="1,0,0,1"
+                                                                    Background="White"
+                                                                    SnapsToDevicePixels="True"/>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
 
-                                            <!-- Сегменты -->
-                                            <ItemsControl ItemsSource="{Binding Segments}"
-                                                          AlternationCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}">
-                                                <ItemsControl.ItemsPanel>
-                                                    <ItemsPanelTemplate>
-                                                        <Grid ui:GridHelpers.ColumnsCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                              ui:GridHelpers.SharedGroupPrefix="GanttCycle"/>
-                                                    </ItemsPanelTemplate>
-                                                </ItemsControl.ItemsPanel>
+                                                <!-- Сегменты -->
+                                                <ItemsControl ItemsSource="{Binding Segments}"
+                                                              AlternationCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                              Panel.ZIndex="1">
+                                                    <ItemsControl.ItemsPanel>
+                                                        <ItemsPanelTemplate>
+                                                            <Grid ui:GridHelpers.ColumnsCount="{Binding DataContext.CycleAxis.Count, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                                  ui:GridHelpers.SharedGroupPrefix="GanttCycle"/>
+                                                        </ItemsPanelTemplate>
+                                                    </ItemsControl.ItemsPanel>
 
-                                                <ItemsControl.ItemContainerStyle>
-                                                    <Style TargetType="ContentPresenter">
-                                                        <Setter Property="Grid.Column" Value="{Binding StartIndex}"/>
-                                                        <Setter Property="Grid.ColumnSpan" Value="{Binding Span}"/>
-                                                    </Style>
-                                                </ItemsControl.ItemContainerStyle>
+                                                    <ItemsControl.ItemContainerStyle>
+                                                        <Style TargetType="ContentPresenter">
+                                                            <Setter Property="Grid.Column" Value="{Binding StartIndex}"/>
+                                                            <Setter Property="Grid.ColumnSpan" Value="{Binding Span}"/>
+                                                        </Style>
+                                                    </ItemsControl.ItemContainerStyle>
 
-                                                <ItemsControl.ItemTemplate>
-                                                    <DataTemplate>
-                                                        <Border Height="28"
-                                                                Margin="2"
-                                                                CornerRadius="4"
-                                                                Background="{Binding Brush}"
-                                                                SnapsToDevicePixels="True">
-                                                            <Border.ToolTip>
-                                                                <StackPanel>
-                                                                    <TextBlock>
-                                                                        <Run Text="Циклы: "/>
-                                                                        <Run Text="{Binding CycleFrom}"/>
-                                                                        <Run Text="–"/>
-                                                                        <Run Text="{Binding CycleTo}"/>
-                                                                    </TextBlock>
-                                                                    <TextBlock Text="{Binding Annotation}" TextWrapping="Wrap"/>
-                                                                </StackPanel>
-                                                            </Border.ToolTip>
-                                                        </Border>
-                                                    </DataTemplate>
-                                                </ItemsControl.ItemTemplate>
-                                            </ItemsControl>
-                                        </Grid>
+                                                    <ItemsControl.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <Border Height="28"
+                                                                    Margin="2"
+                                                                    CornerRadius="4"
+                                                                    Background="{Binding Brush}"
+                                                                    SnapsToDevicePixels="True">
+                                                                <Border.ToolTip>
+                                                                    <StackPanel>
+                                                                        <TextBlock>
+                                                                            <Run Text="Циклы: "/>
+                                                                            <Run Text="{Binding CycleFrom}"/>
+                                                                            <Run Text="–"/>
+                                                                            <Run Text="{Binding CycleTo}"/>
+                                                                        </TextBlock>
+                                                                        <TextBlock Text="{Binding Annotation}" TextWrapping="Wrap"/>
+                                                                    </StackPanel>
+                                                                </Border.ToolTip>
+                                                            </Border>
+                                                        </DataTemplate>
+                                                    </ItemsControl.ItemTemplate>
+                                                </ItemsControl>
+                                            </Grid>
+                                        </Border>
                                     </Grid>
                                 </Border>
                             </DataTemplate>


### PR DESCRIPTION
## Summary
- add cycle meaning groups so gantt rows only contain segments with a single status meaning
- assign default display names to cycle state groups and refresh the flattened gantt data source
- remove the static legend from the cycle scale view to keep the layout focused on the gantt

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_6908564199dc832e92c9fb1f83c468b1