### PR TITLE
Read and debug txt and osd files

### DIFF
--- a/Services/Data/ProjectData.cs
+++ b/Services/Data/ProjectData.cs
@@ -12,7 +12,7 @@ namespace Osadka.Models
         public double? RelNomen { get; set; }
         public double? RelCalculated { get; set; }
         public string? SelectedCycleHeader { get; set; }
-        public int ObjectNumber { get; set; }   // <<< новое поле
+        public int? ObjectNumber { get; set; }   // Nullable для совместимости со старыми файлами
 
         public List<MeasurementRow> DataRows { get; set; } = new();
         public List<CoordRow> CoordRows { get; set; } = new();

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -244,11 +244,14 @@ namespace Osadka.ViewModels
                 vm.ObjectNumbers.Clear();
                 foreach (var k in vm.Objects.Keys.OrderBy(k => k)) vm.ObjectNumbers.Add(k);
 
-                int objectNumber = data.ObjectNumber;
-                if (!vm.ObjectNumbers.Contains(objectNumber))
+                // Для старых файлов без ObjectNumber берем первый доступный объект
+                int objectNumber = data.ObjectNumber ?? vm.ObjectNumbers.FirstOrDefault();
+                if (objectNumber == 0 || !vm.ObjectNumbers.Contains(objectNumber))
+                {
                     objectNumber = vm.ObjectNumbers.FirstOrDefault();
-                if (objectNumber == 0)
-                    objectNumber = 1;
+                    if (objectNumber == 0)
+                        objectNumber = 1;
+                }
                 vm.Header.ObjectNumber = objectNumber;
 
                 vm.CycleNumbers.Clear();


### PR DESCRIPTION
Проблема: После обновления программа не открывала старые файлы .osd без поля ObjectNumber.

Решение:
- Сделано поле ProjectData.ObjectNumber nullable (int?) для обратной совместимости
- Добавлена логика в MainViewModel.LoadProject для определения ObjectNumber из Objects.Keys, если поле отсутствует в старом файле
- Теперь программа корректно открывает как новые, так и старые форматы файлов